### PR TITLE
Update setup.py - importlib in python >= 3.8

### DIFF
--- a/mcf/general_purpose.py
+++ b/mcf/general_purpose.py
@@ -467,7 +467,7 @@ def screen_variables(indatei, var_names, perfectcorr, min_dummy, with_output):
         corr_matrix = datanew.corr().abs()
         # Upper triangle of corr matrix
         upper = corr_matrix.where(np.triu(np.ones(corr_matrix.shape),
-                                          k=1).astype(np.bool))
+                                          k=1).astype(bool))
         to_delete = [c for c in upper.columns if any(upper[c] > 0.999)]
         if not to_delete == []:
             datanew = datanew.drop(columns=to_delete)

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,26 @@
 from distutils.core import setup
 import os
+import sys
 
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+# If Python version < 3.8 need to also install importlib
+required_packages = [
+    'numpy>=1.20.0',
+    'pandas>=1.3.0',
+    'matplotlib>=3.4.2',
+    'scipy>=1.7.0',
+    'ray>=1.4.0',
+    'numba>=0.53.1',
+    'scikit-learn>=0.24.2',
+    'psutil>=5.8.0',
+    'sympy>=1.8',
+    'pathlib>=1.0.1',
+    'dask'
+]
+if not ((sys.version_info[0] >= 3) and (sys.version_info[1] >= 8)):
+    required_packages.append('importlib>=1.0.4')
 
 setup(
   name = 'mcf',
@@ -21,17 +39,5 @@ setup(
     'License :: OSI Approved :: MIT License',
     'Programming Language :: Python :: 3.9'
   ],
-  install_requires=[
-   'numpy>=1.20.0',
-   'pandas>=1.3.0',
-   'matplotlib>=3.4.2',
-   'scipy>=1.7.0',
-   'ray>=1.4.0',
-   'numba>=0.53.1',
-   'scikit-learn>=0.24.2',
-   'psutil>=5.8.0',
-   'importlib>=1.0.4',
-   'sympy>=1.8',
-   'pathlib>=1.0.1',
-   'dask']
+  install_requires=required_packages
 )


### PR DESCRIPTION
Added a check in setup.py for Python versions >= 3.8. In 3.8 importlib and importlib-metadata became part of the standard library. Current install was failing on Python 3.10